### PR TITLE
Adapt to the new 0.7.19 _cli.make_arg_parser signature

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
 
     - name: Upload to Codecov
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         name: pytests-py3.11
         flags: pytests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,8 @@ jobs:
         flags: pytests
         file: ./coverage.xml
         fail_ci_if_error: true
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   pre-commit-hook:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
 
     - name: Upload to Codecov
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v4
       with:
         name: pytests-py3.11
         flags: pytests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   hooks:
   - id: python-check-blanket-noqa
 - repo: https://github.com/timothycrosley/isort
-  rev: 5.11.4
+  rev: 5.13.2
   hooks:
   - id: isort
 - repo: https://github.com/psf/black


### PR DESCRIPTION
Close #2 - Adapt to changes introduced in the `_cli.make_arg_parser` function in the 0.7.19, with backwards compatibility in mind.