### PR TITLE
prefer `functools.cache` on `python>=3.9`

### DIFF
--- a/mdformat_pyproject/plugin.py
+++ b/mdformat_pyproject/plugin.py
@@ -1,6 +1,5 @@
 """Main plugin module."""
 
-import functools
 import pathlib
 import sys
 from typing import Mapping, NoReturn, Optional
@@ -14,8 +13,15 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib
 
+if sys.version_info >= (3, 9):
+    from functools import cache
+else:
+    from functools import lru_cache
+    
+    cache = lru_cache()
 
-@functools.lru_cache()
+
+@cache
 def _find_pyproject_toml_path(search_path: str) -> Optional[pathlib.Path]:
     """Find the pyproject.toml file that corresponds to the search path.
 
@@ -38,7 +44,7 @@ def _find_pyproject_toml_path(search_path: str) -> Optional[pathlib.Path]:
     return None
 
 
-@functools.lru_cache()
+@cache
 def _parse_pyproject(pyproject_path: pathlib.Path) -> Optional[Mapping]:
     """Extract and validate the mdformat options from the pyproject.toml file.
 
@@ -53,7 +59,7 @@ def _parse_pyproject(pyproject_path: pathlib.Path) -> Optional[Mapping]:
         return options
 
 
-@functools.lru_cache()
+@cache
 def _reload_cli_opts() -> Mapping:
     """Re-parse the sys.argv array to deduce which arguments were used in the CLI.
 

--- a/mdformat_pyproject/plugin.py
+++ b/mdformat_pyproject/plugin.py
@@ -17,7 +17,7 @@ if sys.version_info >= (3, 9):
     from functools import cache
 else:
     from functools import lru_cache
-    
+
     cache = lru_cache()
 
 


### PR DESCRIPTION
Because according to [docs](https://docs.python.org/3/library/functools.html):

> Because it never needs to evict old values, this is smaller and faster than [lru_cache()](https://docs.python.org/3/library/functools.html#functools.lru_cache) with a size limit.

On `python < 3.9` it will keep on using `functools.lru_cache`