### PR TITLE
typing fixes

### DIFF
--- a/mdformat_pyproject/plugin.py
+++ b/mdformat_pyproject/plugin.py
@@ -100,7 +100,8 @@ def update_mdit(mdit: markdown_it.MarkdownIt) -> None:
         pyproject_opts = _parse_pyproject(pyproject_path)
         if pyproject_opts is not None:
             cli_opts = _reload_cli_opts()
-            mdformat_options.update(**pyproject_opts, **cli_opts)
+            mdformat_options.update(**pyproject_opts)
+            mdformat_options.update(**cli_opts)
 
 
 RENDERERS: MutableMapping[str, Render] = {}

--- a/mdformat_pyproject/plugin.py
+++ b/mdformat_pyproject/plugin.py
@@ -3,7 +3,7 @@
 import functools
 import pathlib
 import sys
-from typing import MutableMapping, Optional, Sequence
+from typing import MutableMapping, Optional, Sequence, Union
 
 import markdown_it
 import mdformat
@@ -15,7 +15,7 @@ else:
     import tomli as tomllib
 
 
-_ConfigOptions = MutableMapping[str, int | str | Sequence[str]]
+_ConfigOptions = MutableMapping[str, Union[int, str, Sequence[str]]]
 
 
 @functools.lru_cache()

--- a/mdformat_pyproject/plugin.py
+++ b/mdformat_pyproject/plugin.py
@@ -53,6 +53,7 @@ def _parse_pyproject(pyproject_path: pathlib.Path) -> Optional[_ConfigOptions]:
     if options is not None:
         mdformat._conf._validate_keys(options, pyproject_path)
         mdformat._conf._validate_values(options, pyproject_path)
+
     return options
 
 


### PR DESCRIPTION
- replaced `NoReturn` with `None`, as `NoReturn` is the "bottom type" (i.e. the subtype of all types, the opposite of `object`, equivalent to `typing.Never`), and used to annotate functions that *never* return (e.g. because of a `sys.exit` or infinite loop).
- use `MutableMapping` instead of `Mapping`, which is closer to the actual `dict` it annotates, and so it can be used for `mdit.options["mdformat"]`, as well.
- pass the missing generic type arguments to `(Mutable)Mapping` for the (<sub>incorrectly</sub> contravariant) key and (covariant) value types. I assumed that the config values can only assume `int` (implicitly including its subtype `bool`), `str`, or `Sequence[str]`
- introduced a type-alias (without `TypeAlias`, which requires `python<3.10`) for the config options for the sake of DRY
- combined the `{**_, **_}` and the `dict.update` in `update_mdit` (kinda off-topic, but I couldn't help myself)