### PR TITLE
Fix codecov arguments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,12 +52,11 @@ jobs:
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
       uses: codecov/codecov-action@v5
       with:
-        name: pytests-py3.11
-        flags: pytests
-        file: ./coverage.xml
         fail_ci_if_error: true
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.xml
+        flags: pytests
+        name: pytests-py3.11
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   pre-commit-hook:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix a warning about deprecated arguments in the codecov action and also use the token argument instead of the envvar in an attempt to fix the tokenless upload in contributor PRs