### PR TITLE
Fix unspecified text encoding defect

### DIFF
--- a/mdformat_pyproject/plugin.py
+++ b/mdformat_pyproject/plugin.py
@@ -58,6 +58,7 @@ def _parse_pyproject(pyproject_path: pathlib.Path) -> Optional[_ConfigOptions]:
     """
     with pyproject_path.open(mode="rb") as pyproject_file:
         content = tomllib.load(pyproject_file)
+
     options = content.get("tool", {}).get("mdformat")
     if options is not None:
         mdformat._conf._validate_keys(options, pyproject_path)

--- a/mdformat_pyproject/plugin.py
+++ b/mdformat_pyproject/plugin.py
@@ -56,7 +56,8 @@ def _parse_pyproject(pyproject_path: pathlib.Path) -> Optional[_ConfigOptions]:
     The options are searched inside a [tool.mdformat] key within the toml file,
     and they are validated using the default functions from `mdformat._conf`.
     """
-    content = tomllib.loads(pyproject_path.read_text())
+    with pyproject_path.open(mode="rb") as pyproject_file:
+        content = tomllib.load(pyproject_file)
     options = content.get("tool", {}).get("mdformat")
     if options is not None:
         mdformat._conf._validate_keys(options, pyproject_path)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -121,13 +121,13 @@ def test_update_mdit_pyproject():
 _BROKEN_OPTS = {"tool": {"mdformat": {"invalid": "option"}}}
 
 
-@unittest.mock.patch("mdformat_pyproject.plugin.tomllib.loads", lambda _: _BROKEN_OPTS)
+@unittest.mock.patch("mdformat_pyproject.plugin.tomllib.load", lambda _: _BROKEN_OPTS)
 def test_update_mdit_invalid_pyproject():
     """Test update_mdit when there are invlid options inside the pyproject.toml file.
 
     Setup:
-        - Mock tomllib.loads to return an invalid pyproject.toml file.
-        - Also ensure that the loads cache is clear
+        - Mock tomllib.load to return an invalid pyproject.toml file.
+        - Also ensure that the load cache is clear
     Input:
         - mdit with the default opts and a filename located inside the current project.
     Excepted Side Effect:


### PR DESCRIPTION
TOML files shouldn't be read as text, but if so, they must be considered as encoded in UTF-8 rather than the OS default. The encoding was unspecified, leading to the OS default to be used.

![image](https://github.com/user-attachments/assets/f0c3f555-d0d8-45fa-a398-446c473f1c1d)
