### PR TITLE
Upgrade python versions support - drop 3.7 + 3.8 - add 3.12 + 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', 3.11]
+        python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,9 @@ repos:
     - flake8-bugbear
     - flake8-builtins
     - flake8-comprehensions
-- repo: local
+- repo: https://github.com/hukkin/mdformat
+  rev: 0.7.21
   hooks:
   - id: mdformat
-    name: mdformat
-    entry: mdformat
-    language: python
-    types: [markdown]
+    additional_dependencies:
+    - mdformat-pyproject

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 keywords = ["mdformat", "markdown", "markdown-it"]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = [
     "mdformat ~=0.7",
     "tomli ~=2.0; python_version < '3.11'"

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py3{7,8,9,10,11}, coverage, pre-commit, hook
+envlist = py3{9,10,11,12,13}, coverage, pre-commit, hook
 isolated_build = True
 
-[testenv:py3{7,8,9,10,11}]
+[testenv:py3{9,10,11,12,13}]
 extras = test
 commands = pytest {posargs}
 
@@ -19,7 +19,7 @@ extras = dev
 commands = pre-commit run --config .pre-commit-test.yaml {posargs:--all-files --verbose --show-diff-on-failure}
 
 [flake8]
-max-line-length = 88
+max-line-length = 99
 max-complexity = 10
 # These checks violate PEP8 so let's ignore them
 extend-ignore = E203


### PR DESCRIPTION
Upgrade python versions support to adapt to the current release cycle moment