### PR TITLE
Monkey patch to replace read_toml_opts entirely. Resolves #4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: 3.13
     - name: Installation (deps and package)
       run: pip install .
     - uses: pre-commit/action@v2.0.0
@@ -49,7 +49,7 @@ jobs:
         pytest --cov=mdformat_pyproject --cov-report=xml --cov-report=term-missing
 
     - name: Store PR number and commit SHA
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.13
       run: |
         echo "Storing PR number ${{ github.event.number }}"
         echo "${{ github.event.number }}" > pr_number.txt
@@ -63,14 +63,14 @@ jobs:
     # Triggered sub-workflow is not able to detect the original commit/PR which is available
     # in this workflow.
     - name: Store PR number
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.13
       uses: actions/upload-artifact@v4
       with:
         name: pr_number
         path: pr_number.txt
 
     - name: Store commit SHA
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.13
       uses: actions/upload-artifact@v4
       with:
         name: commit_sha
@@ -80,7 +80,7 @@ jobs:
     # is executed by a different workflow `coverage-report.yml`. The reason for this
     # split is because `on.pull_request` workflows don't have access to secrets.
     - name: Store coverage report in artifacts
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.13
       uses: actions/upload-artifact@v4
       with:
         name: codecov_report
@@ -89,7 +89,7 @@ jobs:
     - run: |
         echo "The coverage report was stored in Github artifacts."
         echo "It will be uploaded to Codecov using [codecov.yml] workflow shortly."
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.13
 
   pre-commit-hook:
     runs-on: ubuntu-latest
@@ -99,7 +99,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: 3.13
 
     - name: Installation (deps and package)
       run: |
@@ -118,10 +118,10 @@ jobs:
     steps:
     - name: Checkout source
       uses: actions/checkout@v3
-    - name: Set up Python 3.11
+    - name: Set up Python 3.13
       uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: 3.13
     - name: install flit
       run: |
         pip install flit~=3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ profile = "black"
 [tool.mdformat]
 wrap = 99
 number = true
+exclude = [".tox/**", ".venv/**"]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -6,11 +6,12 @@ import unittest.mock
 
 import markdown_it
 import pytest
-from mdformat._conf import InvalidConfError
 
 from mdformat_pyproject import plugin
 
-THIS_MODULE_PATH = pathlib.Path(__file__).parent
+THIS_MODULE_PATH = pathlib.Path(__file__)
+THIS_MODULE_PARENT = THIS_MODULE_PATH.parent
+PYPROJECT_PATH = THIS_MODULE_PARENT.parent / "pyproject.toml"
 
 
 def setup_function():
@@ -21,29 +22,36 @@ def setup_function():
 
 
 @pytest.fixture
-def fake_filename():
+def nonexistent_path():
     fake_parent = "/fake"
     while pathlib.Path(fake_parent).exists():
         fake_parent += "e"
 
-    return str(pathlib.Path(fake_parent) / "path" / "to" / "a" / "file.md")
+    return pathlib.Path(fake_parent) / "path" / "to" / "a" / "file.md"
 
 
-@unittest.mock.patch("mdformat_pyproject.plugin.pathlib.Path.cwd", lambda: THIS_MODULE_PATH)
-def test__find_pyproject_toml_path_cwd():
-    """Test _find_pyproject_toml_path when search_path is `-`.
+def test__find_pyproject_toml_path_directory_inside_project():
+    """Test _find_pyproject_toml_path when search_path points at a directory within the project.
 
-    Setup:
-        - Patch Path.cwd to return the path of this module, to ensure
-          that the `cwd` points at a subfolder of the project regardless
-          of where the `pytest` command was executed.
     Input:
-        - search_path="-"
+        - search_path=THIS_MODULE_PATH -> directory is inside the project
     Expected output:
         - pyproject.toml of this project.
     """
-    returned = plugin._find_pyproject_toml_path("-")
-    assert returned == THIS_MODULE_PATH.parent / "pyproject.toml"
+    returned = plugin._find_pyproject_toml_path(THIS_MODULE_PARENT)
+    assert returned == PYPROJECT_PATH
+
+
+def test__find_pyproject_toml_path_directory_outside_project(nonexistent_path):
+    """Test _find_pyproject_toml_path when search_path points at a directory within the project.
+
+    Input:
+        - search_path=nonexistent_path.parent -> directory is outside the project
+    Expected output:
+        - pyproject.toml of this project.
+    """
+    returned = plugin._find_pyproject_toml_path(nonexistent_path.parent)
+    assert returned is None
 
 
 def test__find_pyproject_toml_path_file_inside_project():
@@ -54,131 +62,80 @@ def test__find_pyproject_toml_path_file_inside_project():
     Expected output:
         - pyproject.toml of this project.
     """
-    returned = plugin._find_pyproject_toml_path(__file__)
-    assert returned == THIS_MODULE_PATH.parent / "pyproject.toml"
+    returned = plugin._find_pyproject_toml_path(THIS_MODULE_PATH)
+    assert returned == PYPROJECT_PATH
 
 
-def test__find_pyproject_toml_path_file_outside_of_project(fake_filename):
+def test__find_pyproject_toml_path_file_outside_of_project(nonexistent_path):
     """Test _find_pyproject_toml_path when search_path points at a file outside of a project.
 
     Input:
-        - search_path="/fake/folder/path" -> A madeup path to an inexisting folder.
+        - search_path="/fake/folder/path" -> A madeup path to an nonexistent folder.
     Expected output:
         - None
     """
-    returned = plugin._find_pyproject_toml_path(fake_filename)
+    returned = plugin._find_pyproject_toml_path(nonexistent_path)
     assert returned is None
 
 
-def get_mdit(filename, **kwargs):
-    mdit = unittest.mock.Mock(spec_set=markdown_it.MarkdownIt())
+def test_read_toml_opts_with_pyproject():
+    """Test read_toml_opts when there is a pyproject.toml file.
+
+    Input:
+        - conf_dir pointing to this module's folder
+    Expected Output:
+        - Tuple containing:
+          - Dict with the mdformat options from pyproject.toml
+          - Path to the pyproject.toml file
+    """
+    # run
+    opts, path = plugin.read_toml_opts(THIS_MODULE_PATH)
+
+    # assert
+    assert opts == {"wrap": 99, "number": True, "exclude": [".tox/**", ".venv/**"]}
+    assert path == PYPROJECT_PATH
+
+
+def test_read_toml_opts_without_pyproject(nonexistent_path):
+    """Test read_toml_opts when there is no pyproject.toml file.
+
+    Input:
+        - conf_dir pointing to a non-existent folder
+    Expected Output:
+        - Tuple containing:
+          - Empty dict
+          - None
+    """
+    # run
+    opts, path = plugin.read_toml_opts(nonexistent_path)
+
+    # assert
+    assert opts == {}
+    assert path is None
+
+
+def test_update_mdit_no_config():
+    """Test update_mdit which is now a no-op.
+
+    Input:
+        - mdit with arbitrary configuration
+    Expected Side Effect:
+        - mdit options should remain untouched
+    """
+    filename = "/some/file/name.toml"
     mdformat_options = {
         "check": False,
         "end_of_line": "lf",
-        "filename": str(pathlib.Path(filename).resolve()),
+        "filename": filename,
         "number": False,
         "paths": [filename],
         "wrap": 80,
     }
-    mdit.options = {"mdformat": {**mdformat_options, **kwargs}}
-    return mdit
+    mdit = unittest.mock.Mock(spec_set=markdown_it.MarkdownIt())
+    mdit.options = {"mdformat": mdformat_options}
 
-
-def test_update_mdit_no_config(fake_filename):
-    """Test update_mdit when there is no pyproject.toml.
-
-    Input:
-        - mdit with the default opts and a filename located inside a fake folder
-    Excepted Side Effect:
-        - mdit options should remain untouched
-    """
-    mdit = get_mdit(fake_filename)
-    expected_options = copy.deepcopy(mdit.options["mdformat"])
+    expected_options = copy.deepcopy(mdformat_options)
 
     plugin.update_mdit(mdit)
 
-    assert mdit.options["mdformat"] == expected_options
-
-
-def test_update_mdit_pyproject():
-    """Test update_mdit when there is configuration inside the pyproject.toml file.
-
-    Input:
-        - mdit with the default opts and a filename located inside the current project.
-    Excepted Side Effect:
-        - mdit options should be updated to the pyproject values
-    """
-    mdit = get_mdit(__file__)
-
-    plugin.update_mdit(mdit)
-
-    mdformat_options = mdit.options["mdformat"]
-    assert mdformat_options["wrap"] == 99
-    assert mdformat_options["number"] is True
-    assert mdformat_options["end_of_line"] == "lf"
-
-
-_BROKEN_OPTS = {"tool": {"mdformat": {"invalid": "option"}}}
-
-
-@unittest.mock.patch("mdformat_pyproject.plugin.tomllib.load", lambda _: _BROKEN_OPTS)
-def test_update_mdit_invalid_pyproject():
-    """Test update_mdit when there are invlid options inside the pyproject.toml file.
-
-    Setup:
-        - Mock tomllib.load to return an invalid pyproject.toml file.
-        - Also ensure that the load cache is clear
-    Input:
-        - mdit with the default opts and a filename located inside the current project.
-    Excepted Side Effect:
-        - _validate_keys should raise an exception.
-
-    """
-    mdit = get_mdit(__file__)
-
-    with pytest.raises(InvalidConfError):
-        plugin.update_mdit(mdit)
-
-
-@unittest.mock.patch("mdformat_pyproject.plugin.sys.argv", ["mdformat", "--wrap", "70", __file__])
-def test_update_mdit_pyproject_and_cli():
-    """Test update_mdit when there are conflicting pyproject.toml configuration and cli argumnents.
-
-    Setup:
-        - Patch sys.argv to inject cli options different than the pyproject.toml.
-    Input:
-        - mdit with the default opts and a filename located inside the current project.
-    Excepted Side Effect:
-        - mdit options should be updated, with the cli options having priority over the
-          pyproject ones.
-    """
-    mdit = get_mdit(__file__)
-    expected_options = copy.deepcopy(mdit.options["mdformat"])
-
-    plugin.update_mdit(mdit)
-
-    expected_options["wrap"] = 70
-    expected_options["number"] = True
-    assert mdit.options["mdformat"] == expected_options
-
-
-@unittest.mock.patch("mdformat_pyproject.plugin.sys.argv", ["fake", "--wrap", "70", "--unknown"])
-def test_update_mdit_unknown_cli_arguments():
-    """Test update_mdit when there are unknown arguments passed in the command line.
-
-    Setup:
-        - Mock sys.argv to inject unknown cli options.
-    Input:
-        - mdit with the default opts and a filename located inside the current project.
-    Excepted Side Effect:
-        - The CLI arguments are discarded and only the pyproject.toml options are
-          injected into the mdit options.
-    """
-    mdit = get_mdit(__file__)
-    expected_options = copy.deepcopy(mdit.options["mdformat"])
-
-    plugin.update_mdit(mdit)
-
-    expected_options["wrap"] = 99  # Still from pyproject
-    expected_options["number"] = True
     assert mdit.options["mdformat"] == expected_options


### PR DESCRIPTION
Resolves #4 

This PR exploits the fact that plugin modules are imported along with the rest of the `mdformat` code to monkey patch the [`mdformat._conf.read_toml_opts`](https://github.com/hukkin/mdformat/blob/f6ce9c95a374b7aafd15cab080a2c7a8db435984/src/mdformat/_conf.py#L32) and replace it with an equivalent one that loads the options from the `pyproject.toml` file instead of the `.mdformat.toml` one.

This change allows setting in the `pyproject.toml` file all the options that can be set in the `.mdformat.toml` one, including the internal `mdformat` options lile `exclude`, and not just the ones that affect the `markdown_it` object like was happening before.