### PR TITLE
Fix mdformat 1.0.0 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,27 +13,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.13
+        python-version: "3.14"
     - name: Installation (deps and package)
       run: pip install .
-    - uses: pre-commit/action@v2.0.0
+    - uses: pre-commit/action@v3.0.1
 
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
+        python-version: ['3.10', 3.11, 3.12, 3.13, 3.14]
         os: [ubuntu-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -49,7 +49,7 @@ jobs:
         pytest --cov=mdformat_pyproject --cov-report=xml --cov-report=term-missing
 
     - name: Store PR number and commit SHA
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.13
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.14
       run: |
         echo "Storing PR number ${{ github.event.number }}"
         echo "${{ github.event.number }}" > pr_number.txt
@@ -63,14 +63,14 @@ jobs:
     # Triggered sub-workflow is not able to detect the original commit/PR which is available
     # in this workflow.
     - name: Store PR number
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.13
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.14
       uses: actions/upload-artifact@v4
       with:
         name: pr_number
         path: pr_number.txt
 
     - name: Store commit SHA
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.13
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.14
       uses: actions/upload-artifact@v4
       with:
         name: commit_sha
@@ -80,7 +80,7 @@ jobs:
     # is executed by a different workflow `coverage-report.yml`. The reason for this
     # split is because `on.pull_request` workflows don't have access to secrets.
     - name: Store coverage report in artifacts
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.13
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.14
       uses: actions/upload-artifact@v4
       with:
         name: codecov_report
@@ -89,17 +89,17 @@ jobs:
     - run: |
         echo "The coverage report was stored in Github artifacts."
         echo "It will be uploaded to Codecov using [codecov.yml] workflow shortly."
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.13
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.14
 
   pre-commit-hook:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.13
+        python-version: 3.14
 
     - name: Installation (deps and package)
       run: |
@@ -117,11 +117,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v3
-    - name: Set up Python 3.13
-      uses: actions/setup-python@v4
+      uses: actions/checkout@v5
+    - name: Set up Python 3.14
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.13
+        python-version: 3.14
     - name: install flit
       run: |
         pip install flit~=3.0

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: 'Download existing coverage report'
         id: prepare_report
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             var fs = require('fs');
@@ -90,7 +90,7 @@ jobs:
           echo "override_commit=$(<commit_sha.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ steps.parse_previous_artifacts.outputs.override_commit || '' }}
           path: repo_root

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     - flake8-builtins
     - flake8-comprehensions
 - repo: https://github.com/hukkin/mdformat
-  rev: 0.7.21
+  rev: 1.0.0
   hooks:
   - id: mdformat
     additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v6.0.0
   hooks:
   - id: end-of-file-fixer
   - id: mixed-line-ending
@@ -8,19 +8,19 @@ repos:
   - id: check-yaml
   - id: check-toml
 - repo: https://github.com/pre-commit/pygrep-hooks
-  rev: v1.9.0
+  rev: v1.10.0
   hooks:
   - id: python-check-blanket-noqa
 - repo: https://github.com/timothycrosley/isort
-  rev: 5.13.2
+  rev: 7.0.0
   hooks:
   - id: isort
 - repo: https://github.com/psf/black
-  rev: 22.12.0
+  rev: 25.9.0
   hooks:
   - id: black
 - repo: https://github.com/pycqa/flake8
-  rev: 6.0.0
+  rev: 7.3.0
   hooks:
   - id: flake8
     additional_dependencies:
@@ -29,7 +29,7 @@ repos:
     - flake8-builtins
     - flake8-comprehensions
 - repo: https://github.com/hukkin/mdformat
-  rev: 1.0.0
+  rev: 0.7.21
   hooks:
   - id: mdformat
     additional_dependencies:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add the following to your `.pre-commit-config.yaml`:
 
 ```yaml
 - repo: https://github.com/executablebooks/mdformat
-  rev: 0.7.13  # Use the ref you want to point at
+  rev: 1.0.0  # Use the ref you want to point at
   hooks:
     - id: mdformat
       additional_dependencies:

--- a/mdformat_pyproject/plugin.py
+++ b/mdformat_pyproject/plugin.py
@@ -2,6 +2,7 @@
 
 import pathlib
 import sys
+from functools import cache
 from typing import TYPE_CHECKING, MutableMapping, Optional, Sequence, Tuple, Union
 
 import markdown_it
@@ -14,13 +15,6 @@ if sys.version_info >= (3, 11):
     import tomllib
 else:
     import tomli as tomllib
-
-if sys.version_info >= (3, 9):
-    from functools import cache
-else:
-    from functools import lru_cache
-
-    cache = lru_cache()
 
 
 _ConfigOptions = MutableMapping[str, Union[int, str, Sequence[str]]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,16 +15,16 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 keywords = ["mdformat", "markdown", "markdown-it"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
-    "mdformat ~=0.7",
+    "mdformat ~= 1.0.0",
     "tomli ~=2.0; python_version < '3.11'"
 ]
 dynamic = ["version", "description"]
 
 [project.optional-dependencies]
 test = [
-    "pytest~=6.0",
+    "pytest >= 8.4.0",
     "coverage",
     "pytest-cov",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py3{9,10,11,12,13}, coverage, pre-commit, hook
+envlist = py3{10,11,12,13,14}, coverage, pre-commit, hook
 isolated_build = True
 
-[testenv:py3{9,10,11,12,13}]
+[testenv:py3{10,11,12,13,14}]
 extras = test
 commands = pytest {posargs}
 


### PR DESCRIPTION
This PR closes: https://github.com/csala/mdformat-pyproject/issues/18

Given the big changes, I couldn't help but try to update things left and right:
- Bump minimal Python to 3.10 (to align it with `mdformat 1.0.0` owns requirement)
- Remove cache compatibility import for Python 3.9
- Add tests on Python 3.14
- Remove tests on Python 3.9
- Bump `pytest >= 8.4.0` (first version to support Python 3.14) 
- Bump CI GitHub workflow actions

Sorry if this PR feels a bit bigger in scope than simply fixing `mdformat 1.0.0` compatibility. So please tell me if some changes are too aggressive in which case I'll be happy to scale down my propositions.